### PR TITLE
Feature: Update MemeAssembly 

### DIFF
--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -54,13 +54,17 @@ async function checkForUpdate(installedVersionNumber: string, showNoUpdate?: boo
     if (installedVersionNumber == onlineVersionNumber) {
         // Latest version installed
         if (showNoUpdate) {
-            vscode.window.showInformationMessage(`The latest version ${onlineVersionNumber} of MemeAssembly is already installed`)
+            // We only want to show a message, but if the user really wants to install
+            // the version again, we won't stop them
+            await vscode.window
+                .showInformationMessage(`The latest version ${onlineVersionNumber} of MemeAssembly is already installed`, "Reinstall anyways")
+                .then(installIfAccepted);
         }
         return;
     }
 
     vscode.window
-        .showWarningMessage(`A new version of MemeAssembly is available. Do you want to update from version ${installedVersionNumber} to ${onlineVersionNumber}?`, "Update")
+        .showInformationMessage(`A new version of MemeAssembly is available. Do you want to update from version ${installedVersionNumber} to ${onlineVersionNumber}?`, "Update")
         .then(installIfAccepted);
 }
 


### PR DESCRIPTION
This PR adds a new "Update MemeAssembly compiler" command to the extension. It basically runs the already existing installation function.


Things that are not included, but make sense to add:
* Automatically check for updates
  * Fetch the latest MemeAssembly release version from the GitHub API
  * Get the currently installed version (from the `memeasm -h` text)
  * If they differ (or only if the online version is higher?) we show an update notification